### PR TITLE
fix: rate limit error exiting script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/).
+
+---
+
+## [Unreleased]
+
+---
+
+## [1.0.1] - 2025-04-03
+### Changed
+- Renamed `ExtractSummary` function in gemini package to more general `ExtractAnswer`.
+
+### Fixed
+- Fix rate limit error exiting script. ([#1](https://github.com/mteolis/note-goat/issues/1)), ([PR #4](https://github.com/mteolis/note-goat/pull/4))
+    - Implemented `WaitForRateLimit` function to handle Gemini API rate limit errors with retries.
+    - Added exponential backoff logic for handling rate limit errors.
+    - Added logging to notify users when retries are triggered due to rate limits.
+
+## [1.0.0] - 2025-03-30
+### Added
+- Initial release of the project.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ---
 
 ## [1.0.1] - 2025-04-03
+### Added
+- Added `CHANGELOG.md` to track project changes and release history.
+
 ### Changed
 - Renamed `ExtractSummary` function in gemini package to more general `ExtractAnswer`.
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION := 1.0.0
+VERSION := 1.0.1
 APP_NAME := NoteGoat
 BUILD_DIR := build
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION := 1.0.1
+VERSION := v1.0.1
 APP_NAME := NoteGoat
 BUILD_DIR := build
 

--- a/internal/goat/goat.go
+++ b/internal/goat/goat.go
@@ -98,14 +98,14 @@ func AddAISummary() {
 
 		prompt := buildPrompt(sheetString)
 
-		response, err := gemini.Prompt(prompt)
+		response, err := gemini.WaitForRateLimit(prompt)
 		if err != nil {
 			logger.Error("Error prompting Gemini AI: %+v\n", "err", err)
 			log.Printf("Error prompting Gemini AI: %+v\n", err)
 			return
 		}
 
-		summary := gemini.ExtractSummary(response)
+		summary := gemini.ExtractAnswer(response)
 		summary = insertNames(summary, clientFirstName, clientLastName, advisorFirstName, advisorLastName)
 
 		xl.SetCellValue(sheetName, summaryTarget, summary)

--- a/main.go
+++ b/main.go
@@ -15,7 +15,7 @@ import (
 
 var (
 	appName = "NoteGoat"
-	version = "v1.0.0"
+	version = "v1.0.1"
 	logger  *slog.Logger
 )
 


### PR DESCRIPTION
Fixes #1 

add logic to retry prompt and sleep with exponential backoff until response is returned from Gemini API.